### PR TITLE
Allows properties for tasks contained within the CTR

### DIFF
--- a/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/StepBeanDefinitionRegistrar.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/StepBeanDefinitionRegistrar.java
@@ -96,10 +96,10 @@ public class StepBeanDefinitionRegistrar implements ImportBeanDefinitionRegistra
 
 	private ComposedTaskProperties composedTaskProperties() {
 		ComposedTaskProperties properties = new ComposedTaskProperties();
-		String dataFlowUriString = this.env.getProperty("dataFlowUri");
-		String maxWaitTime = this.env.getProperty("maxWaitTime");
+		String dataFlowUriString = this.env.getProperty("dataflow-server-uri");
+		String maxWaitTime = this.env.getProperty("max-wait-time");
 		String intervalTimeBetweenChecks =
-				this.env.getProperty("intervalTimeBetweenChecks");
+				this.env.getProperty("interval-time-between-checks");
 		properties.setGraph(this.env.getProperty("graph"));
 		properties.setComposedTaskArguments(
 				this.env.getProperty("composed-task-arguments"));

--- a/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/StepBeanDefinitionRegistrar.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/StepBeanDefinitionRegistrar.java
@@ -64,6 +64,7 @@ public class StepBeanDefinitionRegistrar implements ImportBeanDefinitionRegistra
 						taskName, taskSuffix));
 				builder.addPropertyValue("taskSpecificProps",
 						getPropertiesForTask(taskName, properties));
+				builder.addPropertyValue("arguments", properties.getComposedTaskArguments());
 
 				registry.registerBeanDefinition(String.format("%s_%s",
 						taskName, taskSuffix), builder.getBeanDefinition());
@@ -101,8 +102,8 @@ public class StepBeanDefinitionRegistrar implements ImportBeanDefinitionRegistra
 				this.env.getProperty("intervalTimeBetweenChecks");
 		properties.setGraph(this.env.getProperty("graph"));
 		properties.setComposedTaskArguments(
-				this.env.getProperty("composedTaskArguments"));
-		properties.setComposedTaskProperties("composedTaskProperties");
+				this.env.getProperty("composed-task-arguments"));
+		properties.setComposedTaskProperties(this.env.getProperty("composed-task-properties"));
 
 		if (maxWaitTime != null) {
 			properties.setMaxWaitTime(Integer.valueOf(maxWaitTime));

--- a/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/ComposedTaskRunnerConfigurationJobIncrementerTests.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/ComposedTaskRunnerConfigurationJobIncrementerTests.java
@@ -45,7 +45,7 @@ import org.springframework.util.Assert;
 		DataFlowTestConfiguration.class,StepBeanDefinitionRegistrar.class,
 		ComposedTaskRunnerConfiguration.class,
 		StepBeanDefinitionRegistrar.class})
-@TestPropertySource(properties = {"graph=AAA && BBB && CCC","maxWaitTime=1000", "incrementInstanceEnabled=true"})
+@TestPropertySource(properties = {"graph=AAA && BBB && CCC","max-wait-time=1000", "increment-instance-enabled=true"})
 public class ComposedTaskRunnerConfigurationJobIncrementerTests {
 
 	@Autowired

--- a/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/ComposedTaskRunnerConfigurationNoPropertiesTests.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/ComposedTaskRunnerConfigurationNoPropertiesTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.task.app.composedtaskrunner;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
+import org.springframework.cloud.dataflow.rest.client.TaskOperations;
+import org.springframework.cloud.task.app.composedtaskrunner.configuration.DataFlowTestConfiguration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.util.Assert;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Glenn Renfro
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes={EmbeddedDataSourceConfiguration.class,
+		TaskLauncherTaskletTests.TestConfiguration.class,
+		PropertyPlaceholderAutoConfiguration.class,
+		DataFlowTestConfiguration.class,StepBeanDefinitionRegistrar.class,
+		ComposedTaskRunnerConfiguration.class,
+		StepBeanDefinitionRegistrar.class})
+@TestPropertySource(properties = {"graph=AAA && BBB && CCC","maxWaitTime=1000"})
+public class ComposedTaskRunnerConfigurationNoPropertiesTests {
+
+	@Autowired
+	private JobRepository jobRepository;
+
+	@Autowired
+	private Job job;
+
+	@Autowired
+	private TaskOperations taskOperations;
+
+	@Test
+	@DirtiesContext
+	public void testComposedConfiguration() throws Exception {
+		JobExecution jobExecution = this.jobRepository.createJobExecution(
+				"ComposedTest", new JobParameters());
+		job.execute(jobExecution);
+
+		Assert.isNull(job.getJobParametersIncrementer(), "JobParametersIncrementer must be null.");
+		verify(this.taskOperations).launch("AAA", new HashMap<String, String>(0), new ArrayList<String>(0));
+	}
+}

--- a/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/ComposedTaskRunnerConfigurationNoPropertiesTests.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/ComposedTaskRunnerConfigurationNoPropertiesTests.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.verify;
 		DataFlowTestConfiguration.class,StepBeanDefinitionRegistrar.class,
 		ComposedTaskRunnerConfiguration.class,
 		StepBeanDefinitionRegistrar.class})
-@TestPropertySource(properties = {"graph=AAA && BBB && CCC","maxWaitTime=1000"})
+@TestPropertySource(properties = {"graph=AAA && BBB && CCC","max-wait-time=1000"})
 public class ComposedTaskRunnerConfigurationNoPropertiesTests {
 
 	@Autowired

--- a/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/ComposedTaskRunnerConfigurationWithPropertiesTests.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/ComposedTaskRunnerConfigurationWithPropertiesTests.java
@@ -33,12 +33,14 @@ import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoCon
 import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
 import org.springframework.cloud.dataflow.rest.client.TaskOperations;
 import org.springframework.cloud.task.app.composedtaskrunner.configuration.DataFlowTestConfiguration;
+import org.springframework.cloud.task.app.composedtaskrunner.properties.ComposedTaskProperties;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.Assert;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -51,9 +53,10 @@ import static org.mockito.Mockito.verify;
 		DataFlowTestConfiguration.class,StepBeanDefinitionRegistrar.class,
 		ComposedTaskRunnerConfiguration.class,
 		StepBeanDefinitionRegistrar.class})
-@TestPropertySource(properties = {"graph=AAA && BBB && CCC","maxWaitTime=1000",
+@TestPropertySource(properties = {"graph=AAA && BBB && CCC","max-wait-time=1010",
 		"composed-task-properties=app.AAA.format=yyyy, app.BBB.format=mm",
-		"composed-task-arguments=--baz=boo"})
+		"interval-time-between-checks=1100", "composed-task-arguments=--baz=boo",
+		"dataflow-server-uri=http://bar"})
 public class ComposedTaskRunnerConfigurationWithPropertiesTests {
 
 	@Autowired
@@ -65,6 +68,9 @@ public class ComposedTaskRunnerConfigurationWithPropertiesTests {
 	@Autowired
 	private TaskOperations taskOperations;
 
+	@Autowired
+	ComposedTaskProperties composedTaskProperties;
+
 	@Test
 	@DirtiesContext
 	public void testComposedConfiguration() throws Exception {
@@ -74,6 +80,9 @@ public class ComposedTaskRunnerConfigurationWithPropertiesTests {
 
 		Map<String, String> props = new HashMap<>(1);
 		props.put("format", "yyyy");
+		assertEquals(1010, composedTaskProperties.getMaxWaitTime());
+		assertEquals(1100, composedTaskProperties.getIntervalTimeBetweenChecks());
+		assertEquals("http://bar", composedTaskProperties.getDataflowServerUri().toASCIIString());
 
 		List<String> args = new ArrayList<>(1);
 		args.add("--baz=boo");

--- a/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/ComposedTaskRunnerConfigurationWithPropertiesTests.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/ComposedTaskRunnerConfigurationWithPropertiesTests.java
@@ -18,6 +18,8 @@ package org.springframework.cloud.task.app.composedtaskrunner;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -49,8 +51,10 @@ import static org.mockito.Mockito.verify;
 		DataFlowTestConfiguration.class,StepBeanDefinitionRegistrar.class,
 		ComposedTaskRunnerConfiguration.class,
 		StepBeanDefinitionRegistrar.class})
-@TestPropertySource(properties = {"graph=AAA && BBB && CCC","maxWaitTime=1000"})
-public class ComposedTaskRunnerConfigurationTests {
+@TestPropertySource(properties = {"graph=AAA && BBB && CCC","maxWaitTime=1000",
+		"composed-task-properties=app.AAA.format=yyyy, app.BBB.format=mm",
+		"composed-task-arguments=--baz=boo"})
+public class ComposedTaskRunnerConfigurationWithPropertiesTests {
 
 	@Autowired
 	private JobRepository jobRepository;
@@ -68,7 +72,12 @@ public class ComposedTaskRunnerConfigurationTests {
 				"ComposedTest", new JobParameters());
 		job.execute(jobExecution);
 
+		Map<String, String> props = new HashMap<>(1);
+		props.put("format", "yyyy");
+
+		List<String> args = new ArrayList<>(1);
+		args.add("--baz=boo");
 		Assert.isNull(job.getJobParametersIncrementer(), "JobParametersIncrementer must be null.");
-		verify(this.taskOperations).launch("AAA", new HashMap<String, String>(0), new ArrayList<String>(0));
+		verify(this.taskOperations).launch("AAA", props, args);
 	}
 }


### PR DESCRIPTION
*[To Test Properties]*
* Assuming AAA && BBB are definitions for the timestamp app
```
task create foo --definition "AAA && BBB"`
task launch foo --properties "app.composed-task-runner.composed-task-properties=app.foo-AAA.app.AAA.format=yyyy"
```
Now check the AAA log to verify that only 2017 is present.

*[To Test Argument]*
* Assuming AAA && BBB are definitions for the timestamp app
```
task create bar --definition "AAA && BBB"`
task launch bar  --arguments "--composed-task-arguments=--format=yyyy"
```
Now check AAA & BBB logs to verify that only 2017 is present.

resolves #11