### PR TITLE
Pushed logic for determining task is complete to execute method

### DIFF
--- a/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/TaskLauncherTasklet.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/TaskLauncherTasklet.java
@@ -41,6 +41,8 @@ import org.springframework.util.Assert;
  * Executes task launch request using Spring Cloud Data Flow's Restful API
  * then returns the execution id once the task launched.
  *
+ * Note: This class is not thread-safe and as such should not be used as a singleton.
+ *
  * @author Glenn Renfro
  */
 public class TaskLauncherTasklet implements Tasklet {

--- a/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/TaskLauncherTasklet.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/TaskLauncherTasklet.java
@@ -59,6 +59,10 @@ public class TaskLauncherTasklet implements Tasklet {
 
 	private static final Log logger = LogFactory.getLog(TaskLauncherTasklet.class);
 
+	private Long executionId;
+
+	private long timeout;
+
 
 	public TaskLauncherTasklet(
 			TaskOperations taskOperations, TaskExplorer taskExplorer,
@@ -96,44 +100,40 @@ public class TaskLauncherTasklet implements Tasklet {
 	/**
 	 * Executes the task as specified by the taskName with the associated
 	 * properties and arguments.
+	 *
 	 * @param contribution mutable state to be passed back to update the current step execution
 	 * @param chunkContext contains the task-execution-id used by the listener.
 	 * @return Repeat status of FINISHED.
 	 */
 	@Override
 	public RepeatStatus execute(StepContribution contribution,
-			ChunkContext chunkContext) throws Exception {
-		String tmpTaskName = this.taskName.substring(0,
-				this.taskName.lastIndexOf('_'));
+			ChunkContext chunkContext) {
+		if (this.executionId == null) {
+			this.timeout = System.currentTimeMillis() +
+					this.composedTaskProperties.getMaxWaitTime();
+			logger.debug("Wait time for this task to complete is " +
+					this.composedTaskProperties.getMaxWaitTime());
+			logger.debug("Interval check time for this task to complete is " +
+					this.composedTaskProperties.getIntervalTimeBetweenChecks());
 
-		List<String> args = this.arguments;
+			String tmpTaskName = this.taskName.substring(0,
+					this.taskName.lastIndexOf('_'));
 
-		ExecutionContext stepExecutionContext = chunkContext.getStepContext().getStepExecution().
-				getExecutionContext();
-		if(stepExecutionContext.containsKey("task-arguments")) {
-			args = (List<String>) stepExecutionContext.get("task-arguments");
+			List<String> args = this.arguments;
+
+			ExecutionContext stepExecutionContext = chunkContext.getStepContext().getStepExecution().
+					getExecutionContext();
+			if (stepExecutionContext.containsKey("task-arguments")) {
+				args = (List<String>) stepExecutionContext.get("task-arguments");
+			}
+
+			this.executionId = this.taskOperations.launch(tmpTaskName,
+					this.properties, args);
+
+			stepExecutionContext.put("task-execution-id", executionId);
+			stepExecutionContext.put("task-arguments", args);
 		}
-
-		long executionId = this.taskOperations.launch(tmpTaskName,
-				this.properties, args);
-
-		stepExecutionContext.put("task-execution-id", executionId);
-		stepExecutionContext.put("task-arguments", args);
-
-		waitForTaskToComplete(executionId);
-
-		return RepeatStatus.FINISHED;
-	}
-
-	private void waitForTaskToComplete(long taskExecutionId) {
-		long timeout = System.currentTimeMillis() +
-				this.composedTaskProperties.getMaxWaitTime();
-		logger.debug("Wait time for this task to complete is " +
-				this.composedTaskProperties.getMaxWaitTime());
-		logger.debug("Interval check time for this task to complete is " +
-				this.composedTaskProperties.getIntervalTimeBetweenChecks());
-
-		while (true) {
+		else {
 			try {
 				Thread.sleep(this.composedTaskProperties.getIntervalTimeBetweenChecks());
 			}
@@ -143,21 +143,23 @@ public class TaskLauncherTasklet implements Tasklet {
 			}
 
 			TaskExecution taskExecution =
-					this.taskExplorer.getTaskExecution(taskExecutionId);
-			if(taskExecution != null && taskExecution.getEndTime() != null) {
-				if(taskExecution.getExitCode() != 0 ) {
+					this.taskExplorer.getTaskExecution(this.executionId);
+			if (taskExecution != null && taskExecution.getEndTime() != null) {
+				if (taskExecution.getExitCode() != 0) {
 					throw new UnexpectedJobExecutionException("Task returned a non zero exit code.");
 				}
-				break;
+				else {
+					return RepeatStatus.FINISHED;
+				}
 			}
-
-			if(this.composedTaskProperties.getMaxWaitTime() > 0 &&
+			if (this.composedTaskProperties.getMaxWaitTime() > 0 &&
 					System.currentTimeMillis() > timeout) {
 				throw new TaskExecutionTimeoutException(String.format(
 						"Timeout occurred while processing task with Execution Id %s",
-						taskExecutionId));
+						this.executionId));
 			}
 		}
+		return RepeatStatus.CONTINUABLE;
 	}
 
 }

--- a/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/TaskLauncherTaskletTests.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/TaskLauncherTaskletTests.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.task.app.composedtaskrunner;
 import java.util.Date;
 
 import javax.sql.DataSource;
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,10 +57,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.web.client.ResourceAccessException;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -126,27 +125,20 @@ public class TaskLauncherTaskletTests {
 
 	@Test
 	@DirtiesContext
-	public void testTaskLauncherTaskletTimeout() throws Exception {
-		boolean isException = false;
+	public void testTaskLauncherTaskletTimeout() {
 		mockReturnValForTaskExecution(1L);
 		this.composedTaskProperties.setMaxWaitTime(1000);
 		this.composedTaskProperties.setIntervalTimeBetweenChecks(1000);
 		TaskLauncherTasklet taskLauncherTasklet = getTaskExecutionTasklet();
 		ChunkContext chunkContext = chunkContext();
-		try {
-			execute(taskLauncherTasklet, null, chunkContext);
-		}
-		catch (TaskExecutionTimeoutException te) {
-			isException = true;
-			assertThat(te.getMessage(),is(equalTo("Timeout occurred while " +
-					"processing task with Execution Id 1")));
-		}
-		assertThat(isException,is(true));
+		Throwable exception = assertThrows(TaskExecutionTimeoutException.class, () -> execute(taskLauncherTasklet, null, chunkContext));
+		Assertions.assertThat(exception.getMessage()).isEqualTo("Timeout occurred while " +
+				"processing task with Execution Id 1");
 	}
+
 	@Test
 	@DirtiesContext
-	public void testInvalidTaskName() throws Exception {
-		String exceptionMessage = null;
+	public void testInvalidTaskName() {
 		final String ERROR_MESSAGE =
 				"Could not find task definition named " + TASK_NAME;
 		VndErrors errors = new VndErrors("message", ERROR_MESSAGE, new Link("ref"));
@@ -157,19 +149,14 @@ public class TaskLauncherTaskletTests {
 						ArgumentMatchers.any());
 		TaskLauncherTasklet taskLauncherTasklet = getTaskExecutionTasklet();
 		ChunkContext chunkContext = chunkContext();
-		try {
-			execute(taskLauncherTasklet, null, chunkContext);
-		}
-		catch (DataFlowClientException dfce) {
-			exceptionMessage = dfce.getMessage();
-		}
-		assertEquals(ERROR_MESSAGE+"\n", exceptionMessage);
+		Throwable exception = assertThrows(DataFlowClientException.class,
+				() -> taskLauncherTasklet.execute(null, chunkContext));
+		Assertions.assertThat(exception.getMessage()).isEqualTo(ERROR_MESSAGE + "\n");
 	}
 
 	@Test
 	@DirtiesContext
-	public void testNoDataFlowServer() throws Exception {
-		String exceptionMessage = null;
+	public void testNoDataFlowServer() {
 		final String ERROR_MESSAGE =
 				"I/O error on GET request for \"http://localhost:9393\": Connection refused; nested exception is java.net.ConnectException: Connection refused";
 		Mockito.doThrow(new ResourceAccessException(ERROR_MESSAGE))
@@ -178,31 +165,21 @@ public class TaskLauncherTaskletTests {
 				ArgumentMatchers.any());
 		TaskLauncherTasklet taskLauncherTasklet = getTaskExecutionTasklet();
 		ChunkContext chunkContext = chunkContext();
-		try {
-			execute(taskLauncherTasklet, null, chunkContext);
-		}
-		catch (ResourceAccessException rae) {
-			exceptionMessage = rae.getMessage();
-		}
-		assertEquals(ERROR_MESSAGE, exceptionMessage);
+		Throwable exception = assertThrows(ResourceAccessException.class,
+				() -> execute(taskLauncherTasklet, null, chunkContext));
+		Assertions.assertThat(exception.getMessage()).isEqualTo(ERROR_MESSAGE);
 	}
 
 	@Test
 	@DirtiesContext
-	public void testTaskLauncherTaskletFailure() throws Exception {
-		boolean isException = false;
+	public void testTaskLauncherTaskletFailure() {
 		mockReturnValForTaskExecution(1L);
 		TaskLauncherTasklet taskLauncherTasklet = getTaskExecutionTasklet();
 		ChunkContext chunkContext = chunkContext();
 		createCompleteTaskExecution(1);
-		try {
-			execute(taskLauncherTasklet, null, chunkContext);
-		}
-		catch (UnexpectedJobExecutionException jobExecutionException) {
-			isException = true;
-			assertThat(jobExecutionException.getMessage(),is(equalTo("Task returned a non zero exit code.")));
-		}
-		assertThat(isException,is(true));
+		Throwable exception = assertThrows(UnexpectedJobExecutionException.class,
+				() -> execute(taskLauncherTasklet, null, chunkContext));
+		Assertions.assertThat(exception.getMessage()).isEqualTo("Task returned a non zero exit code.");
 	}
 
 	private RepeatStatus execute(TaskLauncherTasklet taskLauncherTasklet, StepContribution contribution,

--- a/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/configuration/ComposedRunnerVisitorConfiguration.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/configuration/ComposedRunnerVisitorConfiguration.java
@@ -31,7 +31,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.task.app.composedtaskrunner.ComposedRunnerJobFactory;
 import org.springframework.cloud.task.app.composedtaskrunner.ComposedRunnerVisitor;
 import org.springframework.cloud.task.app.composedtaskrunner.properties.ComposedTaskProperties;
-import org.springframework.cloud.task.configuration.EnableTask;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.TaskExecutor;
@@ -46,7 +45,6 @@ import org.springframework.transaction.interceptor.TransactionAttribute;
  */
 @Configuration
 @EnableBatchProcessing
-@EnableTask
 @EnableConfigurationProperties(ComposedTaskProperties.class)
 public class ComposedRunnerVisitorConfiguration {
 


### PR DESCRIPTION
resolves #52

The primary issue is that the TaskLauncher was checking to see if the task was done by monitoring the TaskExecution table.   However, it was holding the transaction on the row, and it should be releasing it between its check was complete.   However the transaction was maintained during the entire wait cycle and thus on some DBS this would cause a deadlock.   To break this we altered the code so that after each check, it would return continue instead of finished for the tasklet thus releasing the transaction.    And batch would call the task let again and the test was reapplied until it finishes or times out.