### PR TITLE
URL Cleanup

### DIFF
--- a/spring-cloud-starter-task-composedtaskrunner/README.adoc
+++ b/spring-cloud-starter-task-composedtaskrunner/README.adoc
@@ -8,7 +8,7 @@ passed in via the `--graph` command line argument.
 
 == Overview
 The Composed Task Runner parses the graph DSL and for each node in the graph it
-will execute a restful call against a specified http://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/[Spring Cloud Data Flow]
+will execute a restful call against a specified https://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/[Spring Cloud Data Flow]
 instance to launch the associated task definition.  For each task definition that is executed the
 Composed Task Runner will poll the database to verify that the task completed.
 Once complete the Composed Task Runner will either continue to the next task in
@@ -25,9 +25,9 @@ the use of sequences, transitions, splits, or a combination therein.
 
 == Traversing the graph
 Composed Task Runner is built using
-http://docs.spring.io/spring-batch/reference/html/[Spring Batch]
+https://docs.spring.io/spring-batch/reference/html/[Spring Batch]
 to execute the directed graph.   As such each node in the graph is a
-http://docs.spring.io/spring-batch/reference/html/domain.html#domainStep[Step].
+https://docs.spring.io/spring-batch/reference/html/domain.html#domainStep[Step].
 As discussed in the overview, each step in the graph will post a request to a
 Spring Cloud Data Flow Server to execute a task definition.  If the task launched by
 the step fails to complete within the time specified by the `maxWaitTime`

--- a/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/ComposedTaskRunnerConfigurationWithPropertiesTests.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/ComposedTaskRunnerConfigurationWithPropertiesTests.java
@@ -54,7 +54,7 @@ import static org.springframework.cloud.task.app.composedtaskrunner.ComposedTask
 @TestPropertySource(properties = {"graph=AAA && BBB && CCC","max-wait-time=1010",
 		"composed-task-properties=" + COMPOSED_TASK_PROPS ,
 		"interval-time-between-checks=1100", "composed-task-arguments=--baz=boo",
-		"dataflow-server-uri=http://bar"})
+		"dataflow-server-uri=https://bar"})
 public class ComposedTaskRunnerConfigurationWithPropertiesTests {
 
 	@Autowired
@@ -86,7 +86,7 @@ public class ComposedTaskRunnerConfigurationWithPropertiesTests {
 		assertEquals(COMPOSED_TASK_PROPS, composedTaskProperties.getComposedTaskProperties());
 		assertEquals(1010, composedTaskProperties.getMaxWaitTime());
 		assertEquals(1100, composedTaskProperties.getIntervalTimeBetweenChecks());
-		assertEquals("http://bar", composedTaskProperties.getDataflowServerUri().toASCIIString());
+		assertEquals("https://bar", composedTaskProperties.getDataflowServerUri().toASCIIString());
 		List<String> args = new ArrayList<>(1);
 		args.add("--baz=boo");
 		Assert.isNull(job.getJobParametersIncrementer(), "JobParametersIncrementer must be null.");


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://bar (UnknownHostException) with 2 occurrences migrated to:  
  https://bar ([https](https://bar) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/) result 200).
* [ ] http://docs.spring.io/spring-batch/reference/html/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-batch/reference/html/ ([https](https://docs.spring.io/spring-batch/reference/html/) result 301).
* [ ] http://docs.spring.io/spring-batch/reference/html/domain.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-batch/reference/html/domain.html ([https](https://docs.spring.io/spring-batch/reference/html/domain.html) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost:9393 with 7 occurrences
* http://test with 2 occurrences