### PR TITLE
Task Child apps are now launched with parent-execution-id set

### DIFF
--- a/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/ComposedTaskRunnerStepFactory.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/ComposedTaskRunnerStepFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.dataflow.rest.client.TaskOperations;
 import org.springframework.cloud.task.app.composedtaskrunner.properties.ComposedTaskProperties;
 import org.springframework.cloud.task.configuration.TaskConfigurer;
+import org.springframework.cloud.task.configuration.TaskProperties;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
 import org.springframework.transaction.interceptor.TransactionAttribute;
@@ -64,6 +65,9 @@ public class ComposedTaskRunnerStepFactory implements FactoryBean<Step> {
 	@Autowired
 	private TaskConfigurer taskConfigurer;
 
+	@Autowired
+	private TaskProperties taskProperties;
+
 	public ComposedTaskRunnerStepFactory(
 			ComposedTaskProperties composedTaskProperties, String taskName) {
 		Assert.notNull(composedTaskProperties,
@@ -90,7 +94,7 @@ public class ComposedTaskRunnerStepFactory implements FactoryBean<Step> {
 	public Step getObject() throws Exception {
 		TaskLauncherTasklet taskLauncherTasklet = new TaskLauncherTasklet(
 				this.taskOperations, taskConfigurer.getTaskExplorer(),
-				this.composedTaskProperties, this.taskName);
+				this.composedTaskProperties, this.taskName, taskProperties);
 
 		taskLauncherTasklet.setArguments(this.arguments);
 		taskLauncherTasklet.setProperties(this.taskSpecificProps);

--- a/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/ComposedTaskRunnerStepFactoryTests.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/ComposedTaskRunnerStepFactoryTests.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.springframework.cloud.task.app.composedtaskrunner;
 
 import javax.sql.DataSource;
@@ -15,6 +31,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cloud.dataflow.rest.client.TaskOperations;
 import org.springframework.cloud.task.app.composedtaskrunner.properties.ComposedTaskProperties;
 import org.springframework.cloud.task.configuration.TaskConfigurer;
+import org.springframework.cloud.task.configuration.TaskProperties;
 import org.springframework.cloud.task.repository.TaskExplorer;
 import org.springframework.cloud.task.repository.TaskRepository;
 import org.springframework.context.annotation.Bean;
@@ -52,6 +69,11 @@ public class ComposedTaskRunnerStepFactoryTests {
 		public TaskOperations taskOperations;
 
 		@Bean
+		public TaskProperties taskProperties() {
+			return new TaskProperties();
+		}
+
+		@Bean
 		public StepBuilderFactory steps(){
 			return new StepBuilderFactory(mock(JobRepository.class), mock(PlatformTransactionManager.class));
 		}
@@ -82,7 +104,7 @@ public class ComposedTaskRunnerStepFactoryTests {
 		}
 
 		@Bean
-		public ComposedTaskRunnerStepFactory stepFactory() {
+		public ComposedTaskRunnerStepFactory stepFactory(TaskProperties taskProperties) {
 			return new ComposedTaskRunnerStepFactory(new ComposedTaskProperties(), "FOOBAR");
 		}
 	}

--- a/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/TaskLauncherTaskletTests.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/TaskLauncherTaskletTests.java
@@ -88,9 +88,6 @@ public class TaskLauncherTaskletTests {
 	@Autowired
 	private JdbcTaskExecutionDao taskExecutionDao;
 
-	@Autowired
-	private TaskProperties taskProperties;
-
 	private TaskOperations taskOperations;
 
 	private TaskRepository taskRepository;
@@ -146,14 +143,16 @@ public class TaskLauncherTaskletTests {
 		assertEquals(1L, chunkContext.getStepContext()
 				.getStepExecution().getExecutionContext()
 				.get("task-execution-id"));
-		assertNull(((List)chunkContext.getStepContext()
+		assertNull(chunkContext.getStepContext()
 				.getStepExecution().getExecutionContext()
-				.get("task-arguments")));
-		this.taskProperties.setExecutionid(88l);
+				.get("task-arguments"));
+
+		TaskProperties taskProperties = new TaskProperties();
+		taskProperties.setExecutionid(88l);
 		mockReturnValForTaskExecution(2L);
 		chunkContext = chunkContext();
 		createCompleteTaskExecution(0);
-		taskLauncherTasklet = getTaskExecutionTasklet();
+		taskLauncherTasklet = getTaskExecutionTasklet(taskProperties);
 		taskLauncherTasklet.setArguments(null);
 		execute(taskLauncherTasklet, null, chunkContext);
 		assertEquals(2L, chunkContext.getStepContext()
@@ -259,9 +258,13 @@ public class TaskLauncherTaskletTests {
 	}
 
 	private TaskLauncherTasklet getTaskExecutionTasklet() {
+		return getTaskExecutionTasklet(new TaskProperties());
+	}
+
+	private TaskLauncherTasklet getTaskExecutionTasklet(TaskProperties taskProperties) {
 		return new TaskLauncherTasklet(this.taskOperations,
 				this.taskExplorer, this.composedTaskProperties,
-				TASK_NAME, this.taskProperties);
+				TASK_NAME, taskProperties);
 	}
 
 	private ChunkContext chunkContext ()
@@ -288,10 +291,6 @@ public class TaskLauncherTaskletTests {
 	@EnableConfigurationProperties(ComposedTaskProperties.class)
 	public static class TestConfiguration {
 
-		@Bean
-		TaskProperties taskProperties () {
-			return new TaskProperties();
-		}
 
 		@Bean
 		TaskRepositoryInitializer taskRepositoryInitializer() {


### PR DESCRIPTION
so long as the CTR is launched with the executionid passed in.

resolves #89