### PR TITLE
gh-62 Add support for OAuth2 token based authentication

### DIFF
--- a/spring-cloud-starter-task-composedtaskrunner/README.adoc
+++ b/spring-cloud-starter-task-composedtaskrunner/README.adoc
@@ -131,9 +131,10 @@ The **$$ComposedTaskRunner$$** $$task$$ has the following options:
 //tag::configuration-properties[]
 $$composed-task-arguments$$:: $$The arguments to be used for each of the tasks.$$ *($$String$$, default: `$$<none>$$`)*
 $$composed-task-properties$$:: $$The properties to be used for each of the tasks as well as their deployments.$$ *($$String$$, default: `$$<none>$$`)*
-$$dataflow-server-password$$:: $$The optional password for the dataflow server that will receive task launch requests. Used to access the the dataflow server using Basic Authentication.$$ *($$String$$, default: `$$<none>$$`)*
+$$dataflow-server-access-token$$:: $$The optional OAuth2 Access Token.$$ *($$String$$, default: `$$<none>$$`)*
+$$dataflow-server-password$$:: $$The optional password for the dataflow server that will receive task launch requests. Used to access the the dataflow server using Basic Authentication. Not used if {@link #dataflowServerAccessToken} is set.$$ *($$String$$, default: `$$<none>$$`)*
 $$dataflow-server-uri$$:: $$The URI for the dataflow server that will receive task launch requests. Default is http://localhost:9393;$$ *($$URI$$, default: `$$<none>$$`)*
-$$dataflow-server-username$$:: $$The optional username for the dataflow server that will receive task launch requests. Used to access the the dataflow server using Basic Authentication.$$ *($$String$$, default: `$$<none>$$`)*
+$$dataflow-server-username$$:: $$The optional username for the dataflow server that will receive task launch requests. Used to access the the dataflow server using Basic Authentication. Not used if {@link #dataflowServerAccessToken} is set.$$ *($$String$$, default: `$$<none>$$`)*
 $$graph$$:: $$The DSL for the composed task directed graph.$$ *($$String$$, default: `$$<none>$$`)*
 $$increment-instance-enabled$$:: $$Allows a single ComposedTaskRunner instance to be re-executed without changing the parameters. Default is false which means a ComposedTaskRunner instance can only be executed once with a given set of parameters, if true it can be re-executed.$$ *($$Boolean$$, default: `$$false$$`)*
 $$interval-time-between-checks$$:: $$The amount of time in millis that the ComposedTaskRunner will wait between checks of the database to see if a task has completed.$$ *($$Integer$$, default: `$$10000$$`)*

--- a/spring-cloud-starter-task-composedtaskrunner/pom.xml
+++ b/spring-cloud-starter-task-composedtaskrunner/pom.xml
@@ -13,6 +13,9 @@
         <version>2.1.1.BUILD-SNAPSHOT</version>
     </parent>
 
+    <properties>
+        <spring-cloud-common-security-config.version>1.2.0.BUILD-SNAPSHOT</spring-cloud-common-security-config.version>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -52,9 +55,23 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-common-security-config-web</artifactId>
+			<version>${spring-cloud-common-security-config.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.codehaus.jackson</groupId>
+					<artifactId>jackson-mapper-asl</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-web</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
     </dependencies>
 
     <build>

--- a/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/properties/ComposedTaskProperties.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/properties/ComposedTaskProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,15 +62,20 @@ public class ComposedTaskProperties {
 
 	/**
 	 * The optional username for the dataflow server that will receive task launch requests.
-	 * Used to access the the dataflow server using Basic Authentication.
+	 * Used to access the the dataflow server using Basic Authentication. Not used if {@link #dataflowServerAccessToken} is set.
 	 */
 	private String dataflowServerUsername;
 
 	/**
 	 * The optional password for the dataflow server that will receive task launch requests.
-	 * Used to access the the dataflow server using Basic Authentication.
+	 * Used to access the the dataflow server using Basic Authentication. Not used if {@link #dataflowServerAccessToken} is set.
 	 */
 	private String dataflowServerPassword;
+
+	/**
+	 * The optional OAuth2 Access Token.
+	 */
+	private String dataflowServerAccessToken;
 
 	/**
 	 * The DSL for the composed task directed graph.
@@ -260,4 +265,13 @@ public class ComposedTaskProperties {
 	public void setIncrementInstanceEnabled(boolean incrementInstanceEnabled) {
 		this.incrementInstanceEnabled = incrementInstanceEnabled;
 	}
+
+	public String getDataflowServerAccessToken() {
+		return dataflowServerAccessToken;
+	}
+
+	public void setDataflowServerAccessToken(String dataflowServerAccessToken) {
+		this.dataflowServerAccessToken = dataflowServerAccessToken;
+	}
+
 }

--- a/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/ComposedTaskRunnerConfigurationJobIncrementerTests.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/ComposedTaskRunnerConfigurationJobIncrementerTests.java
@@ -23,8 +23,12 @@ import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
+import org.springframework.cloud.common.security.CommonSecurityAutoConfiguration;
+import org.springframework.cloud.common.security.IgnoreAllSecurityConfiguration;
 import org.springframework.cloud.task.app.composedtaskrunner.configuration.DataFlowTestConfiguration;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -39,6 +43,7 @@ import org.springframework.util.Assert;
 		DataFlowTestConfiguration.class,StepBeanDefinitionRegistrar.class,
 		ComposedTaskRunnerConfiguration.class,
 		StepBeanDefinitionRegistrar.class})
+@EnableAutoConfiguration(exclude = { CommonSecurityAutoConfiguration.class})
 @TestPropertySource(properties = {"graph=AAA && BBB && CCC","max-wait-time=1000", "increment-instance-enabled=true"})
 public class ComposedTaskRunnerConfigurationJobIncrementerTests {
 

--- a/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/ComposedTaskRunnerConfigurationNoPropertiesTests.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/ComposedTaskRunnerConfigurationNoPropertiesTests.java
@@ -27,7 +27,9 @@ import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
+import org.springframework.cloud.common.security.CommonSecurityAutoConfiguration;
 import org.springframework.cloud.dataflow.rest.client.TaskOperations;
 import org.springframework.cloud.task.app.composedtaskrunner.configuration.DataFlowTestConfiguration;
 import org.springframework.test.annotation.DirtiesContext;
@@ -47,6 +49,7 @@ import static org.mockito.Mockito.verify;
 		ComposedTaskRunnerConfiguration.class,
 		StepBeanDefinitionRegistrar.class})
 @TestPropertySource(properties = {"graph=AAA && BBB && CCC","max-wait-time=1000"})
+@EnableAutoConfiguration(exclude = { CommonSecurityAutoConfiguration.class})
 public class ComposedTaskRunnerConfigurationNoPropertiesTests {
 
 	@Autowired

--- a/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/ComposedTaskRunnerConfigurationWithPropertiesTests.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/ComposedTaskRunnerConfigurationWithPropertiesTests.java
@@ -29,7 +29,9 @@ import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
+import org.springframework.cloud.common.security.CommonSecurityAutoConfiguration;
 import org.springframework.cloud.dataflow.rest.client.TaskOperations;
 import org.springframework.cloud.task.app.composedtaskrunner.configuration.DataFlowTestConfiguration;
 import org.springframework.cloud.task.app.composedtaskrunner.properties.ComposedTaskProperties;
@@ -55,6 +57,7 @@ import static org.springframework.cloud.task.app.composedtaskrunner.ComposedTask
 		"composed-task-properties=" + COMPOSED_TASK_PROPS ,
 		"interval-time-between-checks=1100", "composed-task-arguments=--baz=boo",
 		"dataflow-server-uri=https://bar"})
+@EnableAutoConfiguration(exclude = { CommonSecurityAutoConfiguration.class})
 public class ComposedTaskRunnerConfigurationWithPropertiesTests {
 
 	@Autowired

--- a/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/configuration/DataFlowConfigurationTests.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/configuration/DataFlowConfigurationTests.java
@@ -17,6 +17,8 @@
 
 package org.springframework.cloud.task.app.composedtaskrunner.configuration;
 
+import java.net.ConnectException;
+import java.net.URI;
 import java.net.URISyntaxException;
 
 import org.junit.Test;
@@ -24,6 +26,7 @@ import org.junit.Test;
 import org.springframework.cloud.task.app.composedtaskrunner.DataFlowConfiguration;
 import org.springframework.cloud.task.app.composedtaskrunner.properties.ComposedTaskProperties;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.ResourceAccessException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -64,4 +67,5 @@ public class DataFlowConfigurationTests {
 		}
 		fail("Expected an IllegalArgumentException to be thrown");
 	}
+
 }

--- a/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/properties/ComposedTaskPropertiesTests.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/properties/ComposedTaskPropertiesTests.java
@@ -43,6 +43,7 @@ public class ComposedTaskPropertiesTests {
 		properties.setGraph("ddd");
 		properties.setDataflowServerUsername("foo");
 		properties.setDataflowServerPassword("bar");
+		properties.setDataflowServerAccessToken("foobar");
 		assertEquals("aaa", properties.getComposedTaskProperties());
 		assertEquals("bbb", properties.getComposedTaskArguments());
 		assertEquals(12345, properties.getIntervalTimeBetweenChecks());
@@ -51,6 +52,7 @@ public class ComposedTaskPropertiesTests {
 		assertEquals("ddd", properties.getGraph());
 		assertEquals("foo", properties.getDataflowServerUsername());
 		assertEquals("bar", properties.getDataflowServerPassword());
+		assertEquals("foobar", properties.getDataflowServerAccessToken());
 	}
 
 	@Test


### PR DESCRIPTION
resolves https://github.com/spring-cloud-task-app-starters/composed-task-runner/issues/62

Depends on:

Move OAuth2AccessTokenProvidingClientHttpRequestInterceptor to Common Security:
https://github.com/spring-cloud/spring-cloud-dataflow/issues/3418

Add OAuth2AccessTokenProvidingClientHttpRequestInterceptor
https://github.com/spring-cloud/spring-cloud-common-security-config/issues/58