### PR TITLE
gh-97 Add Support for Client Credentials Grants

### DIFF
--- a/spring-cloud-starter-task-composedtaskrunner/README.adoc
+++ b/spring-cloud-starter-task-composedtaskrunner/README.adoc
@@ -139,6 +139,10 @@ $$graph$$:: $$The DSL for the composed task directed graph.$$ *($$String$$, defa
 $$increment-instance-enabled$$:: $$Allows a single ComposedTaskRunner instance to be re-executed without changing the parameters. Default is false which means a ComposedTaskRunner instance can only be executed once with a given set of parameters, if true it can be re-executed.$$ *($$Boolean$$, default: `$$false$$`)*
 $$interval-time-between-checks$$:: $$The amount of time in millis that the ComposedTaskRunner will wait between checks of the database to see if a task has completed.$$ *($$Integer$$, default: `$$10000$$`)*
 $$max-wait-time$$:: $$The maximum amount of time in millis that a individual step can run before the execution of the Composed task is failed.$$ *($$Integer$$, default: `$$0$$`)*
+$$oauth2-client-credentials-client-id$$:: $$The OAuth2 Client Id (Used for the client credentials grant). If not null, then the following properties are ignored: <ul>   <li>dataflowServerUsername   <li>dataflowServerPassword   <li>dataflowServerAccessToken <ul>$$ *($$String$$, default: `$$<none>$$`)*
+$$oauth2-client-credentials-client-secret$$:: $$The OAuth2 Client Secret (Used for the client credentials grant).$$ *($$String$$, default: `$$<none>$$`)*
+$$oauth2-client-credentials-scopes$$:: $$OAuth2 Authorization scopes (Used for the client credentials grant).$$ *($$Set<String>$$, default: `$$<none>$$`)*
+$$oauth2-client-credentials-token-uri$$:: $$Token URI for the OAuth2 provider (Used for the client credentials grant).$$ *($$String$$, default: `$$<none>$$`)*
 $$split-thread-allow-core-thread-timeout$$:: $$Specifies whether to allow split core threads to timeout. Default is false;$$ *($$Boolean$$, default: `$$false$$`)*
 $$split-thread-core-pool-size$$:: $$Split's core pool size. Default is 4;$$ *($$Integer$$, default: `$$4$$`)*
 $$split-thread-keep-alive-seconds$$:: $$Split's thread keep alive seconds. Default is 60.$$ *($$Integer$$, default: `$$60$$`)*

--- a/spring-cloud-starter-task-composedtaskrunner/pom.xml
+++ b/spring-cloud-starter-task-composedtaskrunner/pom.xml
@@ -15,6 +15,7 @@
 
     <properties>
         <spring-cloud-common-security-config.version>1.1.3.RELEASE</spring-cloud-common-security-config.version>
+        <spring-security.version>5.2.0.RC1</spring-security.version>
     </properties>
     <dependencies>
         <dependency>
@@ -72,7 +73,12 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-    </dependencies>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-oauth2-client</artifactId>
+			<version>${spring-security.version}</version>
+		</dependency>
+	</dependencies>
 
     <build>
         <plugins>

--- a/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/DataFlowConfiguration.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/DataFlowConfiguration.java
@@ -27,8 +27,18 @@ import org.springframework.cloud.dataflow.rest.client.DataFlowTemplate;
 import org.springframework.cloud.dataflow.rest.client.TaskOperations;
 import org.springframework.cloud.dataflow.rest.util.HttpClientConfigurer;
 import org.springframework.cloud.task.app.composedtaskrunner.properties.ComposedTaskProperties;
+import org.springframework.cloud.task.app.composedtaskrunner.support.OnOAuth2ClientCredentialsEnabled;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.endpoint.DefaultClientCredentialsTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2ClientCredentialsGrantRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 
@@ -53,26 +63,57 @@ public class DataFlowConfiguration {
 	}
 
 	@Bean
-	public DataFlowOperations dataFlowOperations() {
+	public DataFlowOperations dataFlowOperations(ClientRegistrationRepository  clientRegistrations,
+			OAuth2AccessTokenResponseClient<OAuth2ClientCredentialsGrantRequest> clientCredentialsTokenResponseClient) {
 		final RestTemplate restTemplate = DataFlowTemplate.getDefaultDataflowRestTemplate();
 		validateUsernamePassword(this.properties.getDataflowServerUsername(), this.properties.getDataflowServerPassword());
-		if (StringUtils.hasText(this.properties.getDataflowServerAccessToken())) {
-			restTemplate.setRequestFactory(
-				HttpClientConfigurer.create(this.properties.getDataflowServerUri()).buildClientHttpRequestFactory()
-			);
-			restTemplate.getInterceptors().add(new OAuth2AccessTokenProvidingClientHttpRequestInterceptor(this.properties.getDataflowServerAccessToken()));
+
+		final HttpClientConfigurer clientHttpRequestFactoryBuilder;
+
+		if (this.properties.getOauth2ClientCredentials() != null
+				|| StringUtils.hasText(this.properties.getDataflowServerAccessToken())
+				|| (StringUtils.hasText(this.properties.getDataflowServerUsername())
+						&& StringUtils.hasText(this.properties.getDataflowServerPassword())
+					)
+			) {
+			clientHttpRequestFactoryBuilder = HttpClientConfigurer.create(this.properties.getDataflowServerUri());
+		}
+		else {
+			clientHttpRequestFactoryBuilder = null;
+		}
+
+		final String accessTokenValue;
+
+		if (this.properties.getOauth2ClientCredentials() != null) {
+			final ClientRegistration clientRegistration = clientRegistrations.findByRegistrationId("default");
+			final OAuth2ClientCredentialsGrantRequest grantRequest = new OAuth2ClientCredentialsGrantRequest(clientRegistration);
+			final OAuth2AccessTokenResponse res = clientCredentialsTokenResponseClient.getTokenResponse(grantRequest);
+			accessTokenValue = res.getAccessToken().getTokenValue();
+			logger.debug("Configured OAuth2 Client Credentials for accessing the Data Flow Server");
+		}
+		else if (StringUtils.hasText(this.properties.getDataflowServerAccessToken())) {
+			accessTokenValue = this.properties.getDataflowServerAccessToken();
 			logger.debug("Configured OAuth2 Access Token for accessing the Data Flow Server");
 		}
 		else if (StringUtils.hasText(this.properties.getDataflowServerUsername())
 				&& StringUtils.hasText(this.properties.getDataflowServerPassword())) {
-			restTemplate.setRequestFactory(HttpClientConfigurer.create(this.properties.getDataflowServerUri())
-					.basicAuthCredentials(properties.getDataflowServerUsername(), properties.getDataflowServerPassword())
-					.buildClientHttpRequestFactory());
+			accessTokenValue = null;
+			clientHttpRequestFactoryBuilder.basicAuthCredentials(properties.getDataflowServerUsername(), properties.getDataflowServerPassword());
 			logger.debug("Configured basic security for accessing the Data Flow Server");
 		}
 		else {
+			accessTokenValue = null;
 			logger.debug("Not configuring basic security for accessing the Data Flow Server");
 		}
+
+		if (accessTokenValue != null) {
+			restTemplate.getInterceptors().add(new OAuth2AccessTokenProvidingClientHttpRequestInterceptor(accessTokenValue));
+		}
+
+		if (clientHttpRequestFactoryBuilder != null) {
+			restTemplate.setRequestFactory(clientHttpRequestFactoryBuilder.buildClientHttpRequestFactory());
+		}
+
 		return new DataFlowTemplate(this.properties.getDataflowServerUri(), restTemplate);
 	}
 
@@ -82,6 +123,33 @@ public class DataFlowConfiguration {
 		}
 		if (StringUtils.isEmpty(password) && !StringUtils.isEmpty(userName)) {
 			throw new IllegalArgumentException("A username may be specified only together with a password");
+		}
+	}
+
+	@Configuration
+	@Conditional(OnOAuth2ClientCredentialsEnabled.class)
+	static class clientCredentialsConfiguration {
+		{
+			System.out.println("Client Credentials Enabled");
+		}
+
+		@Bean
+		public InMemoryClientRegistrationRepository clientRegistrationRepository(
+				ComposedTaskProperties properties) {
+			final ClientRegistration clientRegistration = ClientRegistration
+					.withRegistrationId("default")
+					.authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+					.tokenUri(properties.getOauth2ClientCredentials().getTokenUri())
+					.clientId(properties.getOauth2ClientCredentials().getClientId())
+					.clientSecret(properties.getOauth2ClientCredentials().getClientSecret())
+					.scope(properties.getOauth2ClientCredentials().getScopes())
+					.build();
+			return new InMemoryClientRegistrationRepository(clientRegistration);
+		}
+
+		@Bean
+		OAuth2AccessTokenResponseClient<OAuth2ClientCredentialsGrantRequest> clientCredentialsTokenResponseClient() {
+			return new DefaultClientCredentialsTokenResponseClient();
 		}
 	}
 }

--- a/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/DataFlowConfiguration.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/DataFlowConfiguration.java
@@ -68,21 +68,16 @@ public class DataFlowConfiguration {
 		final RestTemplate restTemplate = DataFlowTemplate.getDefaultDataflowRestTemplate();
 		validateUsernamePassword(this.properties.getDataflowServerUsername(), this.properties.getDataflowServerPassword());
 
-		final HttpClientConfigurer clientHttpRequestFactoryBuilder;
+		HttpClientConfigurer clientHttpRequestFactoryBuilder = null;
 
 		if (this.properties.getOauth2ClientCredentials() != null
 				|| StringUtils.hasText(this.properties.getDataflowServerAccessToken())
 				|| (StringUtils.hasText(this.properties.getDataflowServerUsername())
-						&& StringUtils.hasText(this.properties.getDataflowServerPassword())
-					)
-			) {
+						&& StringUtils.hasText(this.properties.getDataflowServerPassword()))) {
 			clientHttpRequestFactoryBuilder = HttpClientConfigurer.create(this.properties.getDataflowServerUri());
 		}
-		else {
-			clientHttpRequestFactoryBuilder = null;
-		}
 
-		final String accessTokenValue;
+		String accessTokenValue = null;
 
 		if (this.properties.getOauth2ClientCredentials() != null) {
 			final ClientRegistration clientRegistration = clientRegistrations.findByRegistrationId("default");
@@ -102,7 +97,6 @@ public class DataFlowConfiguration {
 			logger.debug("Configured basic security for accessing the Data Flow Server");
 		}
 		else {
-			accessTokenValue = null;
 			logger.debug("Not configuring basic security for accessing the Data Flow Server");
 		}
 
@@ -129,10 +123,6 @@ public class DataFlowConfiguration {
 	@Configuration
 	@Conditional(OnOAuth2ClientCredentialsEnabled.class)
 	static class clientCredentialsConfiguration {
-		{
-			System.out.println("Client Credentials Enabled");
-		}
-
 		@Bean
 		public InMemoryClientRegistrationRepository clientRegistrationRepository(
 				ComposedTaskProperties properties) {

--- a/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/DataFlowConfiguration.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/DataFlowConfiguration.java
@@ -62,15 +62,22 @@ public class DataFlowConfiguration {
 		return dataFlowOperations.taskOperations();
 	}
 
+	/**
+	 * @param clientRegistrations Can be null. Only required for Client Credentials Grant authentication
+	 * @param clientCredentialsTokenResponseClient Can be null. Only required for Client Credentials Grant authentication
+	 * @return DataFlowOperations
+	 */
 	@Bean
-	public DataFlowOperations dataFlowOperations(ClientRegistrationRepository  clientRegistrations,
-			OAuth2AccessTokenResponseClient<OAuth2ClientCredentialsGrantRequest> clientCredentialsTokenResponseClient) {
+	public DataFlowOperations dataFlowOperations(
+		@Autowired(required = false) ClientRegistrationRepository  clientRegistrations,
+		@Autowired(required = false) OAuth2AccessTokenResponseClient<OAuth2ClientCredentialsGrantRequest> clientCredentialsTokenResponseClient) {
+
 		final RestTemplate restTemplate = DataFlowTemplate.getDefaultDataflowRestTemplate();
 		validateUsernamePassword(this.properties.getDataflowServerUsername(), this.properties.getDataflowServerPassword());
 
 		HttpClientConfigurer clientHttpRequestFactoryBuilder = null;
 
-		if (this.properties.getOauth2ClientCredentials() != null
+		if (this.properties.getOauth2ClientCredentialsClientId() != null
 				|| StringUtils.hasText(this.properties.getDataflowServerAccessToken())
 				|| (StringUtils.hasText(this.properties.getDataflowServerUsername())
 						&& StringUtils.hasText(this.properties.getDataflowServerPassword()))) {
@@ -79,7 +86,7 @@ public class DataFlowConfiguration {
 
 		String accessTokenValue = null;
 
-		if (this.properties.getOauth2ClientCredentials() != null) {
+		if (this.properties.getOauth2ClientCredentialsClientId() != null) {
 			final ClientRegistration clientRegistration = clientRegistrations.findByRegistrationId("default");
 			final OAuth2ClientCredentialsGrantRequest grantRequest = new OAuth2ClientCredentialsGrantRequest(clientRegistration);
 			final OAuth2AccessTokenResponse res = clientCredentialsTokenResponseClient.getTokenResponse(grantRequest);
@@ -129,10 +136,10 @@ public class DataFlowConfiguration {
 			final ClientRegistration clientRegistration = ClientRegistration
 					.withRegistrationId("default")
 					.authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
-					.tokenUri(properties.getOauth2ClientCredentials().getTokenUri())
-					.clientId(properties.getOauth2ClientCredentials().getClientId())
-					.clientSecret(properties.getOauth2ClientCredentials().getClientSecret())
-					.scope(properties.getOauth2ClientCredentials().getScopes())
+					.tokenUri(properties.getOauth2ClientCredentialsTokenUri())
+					.clientId(properties.getOauth2ClientCredentialsClientId())
+					.clientSecret(properties.getOauth2ClientCredentialsClientSecret())
+					.scope(properties.getOauth2ClientCredentialsScopes())
 					.build();
 			return new InMemoryClientRegistrationRepository(clientRegistration);
 		}

--- a/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/properties/ComposedTaskProperties.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/properties/ComposedTaskProperties.java
@@ -301,12 +301,12 @@ public class ComposedTaskProperties {
 	public static class OAuth2ClientCredentials {
 
 		/**
-		 * The optional OAuth2 Access Token.
+		 * The OAuth2 Client Id (Used for the client credentials grant).
 		 */
 		private String clientId;
 
 		/**
-		 * The optional OAuth2 Access Token.
+		 * The OAuth2 Client Secret (Used for the client credentials grant).
 		 */
 		private String clientSecret;
 

--- a/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/properties/ComposedTaskProperties.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/properties/ComposedTaskProperties.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.task.app.composedtaskrunner.properties;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Set;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -76,6 +77,18 @@ public class ComposedTaskProperties {
 	 * The optional OAuth2 Access Token.
 	 */
 	private String dataflowServerAccessToken;
+
+	/**
+	 * The optional OAuth2 Client Credentials. If not null,
+	 * then the following properties are ignored:
+	 *
+	 * <ul>
+	 *   <li>dataflowServerUsername
+	 *   <li>dataflowServerPassword
+	 *   <li>dataflowServerAccessToken
+	 * <ul>
+	 */
+	private OAuth2ClientCredentials oauth2ClientCredentials;
 
 	/**
 	 * The DSL for the composed task directed graph.
@@ -274,4 +287,69 @@ public class ComposedTaskProperties {
 		this.dataflowServerAccessToken = dataflowServerAccessToken;
 	}
 
+	public OAuth2ClientCredentials getOauth2ClientCredentials() {
+		return oauth2ClientCredentials;
+	}
+
+	public void setOauth2ClientCredentials(OAuth2ClientCredentials oauth2ClientCredentials) {
+		this.oauth2ClientCredentials = oauth2ClientCredentials;
+	}
+
+	/**
+	 * OAuth Client Credentials.
+	 */
+	public static class OAuth2ClientCredentials {
+
+		/**
+		 * The optional OAuth2 Access Token.
+		 */
+		private String clientId;
+
+		/**
+		 * The optional OAuth2 Access Token.
+		 */
+		private String clientSecret;
+
+		/**
+		 * Token URI for the provider.
+		 */
+		private String tokenUri;
+
+		/**
+		 * Authorization scopes.
+		 */
+		private Set<String> scopes;
+
+		public String getClientId() {
+			return clientId;
+		}
+
+		public void setClientId(String clientId) {
+			this.clientId = clientId;
+		}
+
+		public String getClientSecret() {
+			return clientSecret;
+		}
+
+		public void setClientSecret(String clientSecret) {
+			this.clientSecret = clientSecret;
+		}
+
+		public String getTokenUri() {
+			return tokenUri;
+		}
+
+		public void setTokenUri(String tokenUri) {
+			this.tokenUri = tokenUri;
+		}
+
+		public Set<String> getScopes() {
+			return scopes;
+		}
+
+		public void setScope(Set<String> scopes) {
+			this.scopes = scopes;
+		}
+	}
 }

--- a/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/properties/ComposedTaskProperties.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/properties/ComposedTaskProperties.java
@@ -79,8 +79,9 @@ public class ComposedTaskProperties {
 	private String dataflowServerAccessToken;
 
 	/**
-	 * The optional OAuth2 Client Credentials. If not null,
-	 * then the following properties are ignored:
+	 * The OAuth2 Client Id (Used for the client credentials grant).
+	 *
+	 * If not null, then the following properties are ignored:
 	 *
 	 * <ul>
 	 *   <li>dataflowServerUsername
@@ -88,7 +89,22 @@ public class ComposedTaskProperties {
 	 *   <li>dataflowServerAccessToken
 	 * <ul>
 	 */
-	private OAuth2ClientCredentials oauth2ClientCredentials;
+	private String oauth2ClientCredentialsClientId;
+
+	/**
+	 * The OAuth2 Client Secret (Used for the client credentials grant).
+	 */
+	private String oauth2ClientCredentialsClientSecret;
+
+	/**
+	 * Token URI for the OAuth2 provider (Used for the client credentials grant).
+	 */
+	private String oauth2ClientCredentialsTokenUri;
+
+	/**
+	 * OAuth2 Authorization scopes (Used for the client credentials grant).
+	 */
+	private Set<String> oauth2ClientCredentialsScopes;
 
 	/**
 	 * The DSL for the composed task directed graph.
@@ -287,69 +303,36 @@ public class ComposedTaskProperties {
 		this.dataflowServerAccessToken = dataflowServerAccessToken;
 	}
 
-	public OAuth2ClientCredentials getOauth2ClientCredentials() {
-		return oauth2ClientCredentials;
+	public String getOauth2ClientCredentialsClientId() {
+		return oauth2ClientCredentialsClientId;
 	}
 
-	public void setOauth2ClientCredentials(OAuth2ClientCredentials oauth2ClientCredentials) {
-		this.oauth2ClientCredentials = oauth2ClientCredentials;
+	public void setOauth2ClientCredentialsClientId(String oauth2ClientCredentialsClientId) {
+		this.oauth2ClientCredentialsClientId = oauth2ClientCredentialsClientId;
 	}
 
-	/**
-	 * OAuth Client Credentials.
-	 */
-	public static class OAuth2ClientCredentials {
-
-		/**
-		 * The OAuth2 Client Id (Used for the client credentials grant).
-		 */
-		private String clientId;
-
-		/**
-		 * The OAuth2 Client Secret (Used for the client credentials grant).
-		 */
-		private String clientSecret;
-
-		/**
-		 * Token URI for the provider.
-		 */
-		private String tokenUri;
-
-		/**
-		 * Authorization scopes.
-		 */
-		private Set<String> scopes;
-
-		public String getClientId() {
-			return clientId;
-		}
-
-		public void setClientId(String clientId) {
-			this.clientId = clientId;
-		}
-
-		public String getClientSecret() {
-			return clientSecret;
-		}
-
-		public void setClientSecret(String clientSecret) {
-			this.clientSecret = clientSecret;
-		}
-
-		public String getTokenUri() {
-			return tokenUri;
-		}
-
-		public void setTokenUri(String tokenUri) {
-			this.tokenUri = tokenUri;
-		}
-
-		public Set<String> getScopes() {
-			return scopes;
-		}
-
-		public void setScope(Set<String> scopes) {
-			this.scopes = scopes;
-		}
+	public String getOauth2ClientCredentialsClientSecret() {
+		return oauth2ClientCredentialsClientSecret;
 	}
+
+	public void setOauth2ClientCredentialsClientSecret(String oauth2ClientCredentialsClientSecret) {
+		this.oauth2ClientCredentialsClientSecret = oauth2ClientCredentialsClientSecret;
+	}
+
+	public String getOauth2ClientCredentialsTokenUri() {
+		return oauth2ClientCredentialsTokenUri;
+	}
+
+	public void setOauth2ClientCredentialsTokenUri(String oauth2ClientCredentialsTokenUri) {
+		this.oauth2ClientCredentialsTokenUri = oauth2ClientCredentialsTokenUri;
+	}
+
+	public Set<String> getOauth2ClientCredentialsScopes() {
+		return oauth2ClientCredentialsScopes;
+	}
+
+	public void setOauth2ClientCredentialsScopes(Set<String> oauth2ClientCredentialsScopes) {
+		this.oauth2ClientCredentialsScopes = oauth2ClientCredentialsScopes;
+	}
+
 }

--- a/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/support/OnOAuth2ClientCredentialsEnabled.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/support/OnOAuth2ClientCredentialsEnabled.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.task.app.composedtaskrunner.support;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * {@link Condition} that is only valid if the property
+ * {@code oauth2-client-credentials} exists.
+ *
+ * @author Gunnar Hillert
+ */
+public class OnOAuth2ClientCredentialsEnabled extends SpringBootCondition {
+
+	@Override
+	public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
+		Map<String, String> properties = getSubProperties(context.getEnvironment(), "oauth2-client-credentials");
+		return new ConditionOutcome(!properties.isEmpty(), "OAuth2 Enabled");
+	}
+
+	public static Map<String, String> getSubProperties(Environment environment, String keyPrefix) {
+		return Binder.get(environment)
+			.bind(keyPrefix, Bindable.mapOf(String.class, String.class))
+			.orElseGet(Collections::emptyMap);
+	}
+}

--- a/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/support/OnOAuth2ClientCredentialsEnabled.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/main/java/org/springframework/cloud/task/app/composedtaskrunner/support/OnOAuth2ClientCredentialsEnabled.java
@@ -15,17 +15,12 @@
  */
 package org.springframework.cloud.task.app.composedtaskrunner.support;
 
-import java.util.Collections;
-import java.util.Map;
-
 import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
 import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
-import org.springframework.boot.context.properties.bind.Bindable;
-import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
-import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.util.StringUtils;
 
 /**
  * {@link Condition} that is only valid if the property
@@ -37,13 +32,8 @@ public class OnOAuth2ClientCredentialsEnabled extends SpringBootCondition {
 
 	@Override
 	public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
-		Map<String, String> properties = getSubProperties(context.getEnvironment(), "oauth2-client-credentials");
-		return new ConditionOutcome(!properties.isEmpty(), "OAuth2 Enabled");
+		String propertyValue = context.getEnvironment().getProperty("oauth2-client-credentials-client-id");
+		return new ConditionOutcome(StringUtils.hasText(propertyValue), "OAuth2 Enabled");
 	}
 
-	public static Map<String, String> getSubProperties(Environment environment, String keyPrefix) {
-		return Binder.get(environment)
-			.bind(keyPrefix, Bindable.mapOf(String.class, String.class))
-			.orElseGet(Collections::emptyMap);
-	}
 }

--- a/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/configuration/DataFlowConfigurationTests.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/configuration/DataFlowConfigurationTests.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,6 @@
 
 package org.springframework.cloud.task.app.composedtaskrunner.configuration;
 
-import java.net.ConnectException;
-import java.net.URI;
 import java.net.URISyntaxException;
 
 import org.junit.Test;
@@ -26,7 +24,6 @@ import org.junit.Test;
 import org.springframework.cloud.task.app.composedtaskrunner.DataFlowConfiguration;
 import org.springframework.cloud.task.app.composedtaskrunner.properties.ComposedTaskProperties;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.web.client.ResourceAccessException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -43,7 +40,7 @@ public class DataFlowConfigurationTests {
 		final DataFlowConfiguration dataFlowConfiguration = new DataFlowConfiguration();
 		ReflectionTestUtils.setField(dataFlowConfiguration, "properties", composedTaskProperties);
 		try {
-			dataFlowConfiguration.taskOperations(dataFlowConfiguration.dataFlowOperations());
+			dataFlowConfiguration.taskOperations(dataFlowConfiguration.dataFlowOperations(null, null));
 		}
 		catch (IllegalArgumentException e) {
 			assertEquals("A username may be specified only together with a password", e.getMessage());
@@ -59,7 +56,7 @@ public class DataFlowConfigurationTests {
 		final DataFlowConfiguration dataFlowConfiguration = new DataFlowConfiguration();
 		ReflectionTestUtils.setField(dataFlowConfiguration, "properties", composedTaskProperties);
 		try {
-			dataFlowConfiguration.taskOperations(dataFlowConfiguration.dataFlowOperations());
+			dataFlowConfiguration.taskOperations(dataFlowConfiguration.dataFlowOperations(null, null));
 		}
 		catch (IllegalArgumentException e) {
 			assertEquals("A password may be specified only together with a username", e.getMessage());

--- a/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/support/OnOAuth2ClientCredentialsEnabledTests.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/support/OnOAuth2ClientCredentialsEnabledTests.java
@@ -44,24 +44,18 @@ public class OnOAuth2ClientCredentialsEnabledTests {
 	public void noPropertySet() throws Exception {
 		this.context = load(Config.class);
 		assertThat(context.containsBean("myBean"), equalTo(false));
-		context.close();
-	}
-
-	@Test(expected=IllegalStateException.class)
-	public void propertySecurityOauth() throws Exception {
-		load(Config.class, "oauth2-client-credentials");
 	}
 
 	@Test
 	public void propertyClientId() throws Exception {
-		this.context = load(Config.class, "oauth2-client-credentials.client-id:12345");
+		this.context = load(Config.class, "oauth2-client-credentials-client-id:12345");
 		assertThat(context.containsBean("myBean"), equalTo(true));
 	}
 
 	@Test
 	public void clientIdOnlyWithNoValue() throws Exception {
-		this.context = load(Config.class, "oauth2-client-credentials.client-id");
-		assertThat(context.containsBean("myBean"), equalTo(true));
+		this.context = load(Config.class, "oauth2-client-credentials-client-id:");
+		assertThat(context.containsBean("myBean"), equalTo(false));
 	}
 
 	private AnnotationConfigApplicationContext load(Class<?> config, String... env) {

--- a/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/support/OnOAuth2ClientCredentialsEnabledTests.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/support/OnOAuth2ClientCredentialsEnabledTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.task.app.composedtaskrunner.support;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Gunnar Hillert
+ */
+public class OnOAuth2ClientCredentialsEnabledTests {
+
+	@Test
+	public void noPropertySet() throws Exception {
+		AnnotationConfigApplicationContext context = load(Config.class);
+		assertThat(context.containsBean("myBean"), equalTo(false));
+		context.close();
+	}
+
+	@Test(expected=IllegalStateException.class)
+	public void propertySecurityOauth() throws Exception {
+		load(Config.class, "oauth2-client-credentials");
+	}
+
+	@Test
+	public void propertyClientId() throws Exception {
+		AnnotationConfigApplicationContext context = load(Config.class, "oauth2-client-credentials.client-id:12345");
+		assertThat(context.containsBean("myBean"), equalTo(true));
+		context.close();
+	}
+
+	@Test
+	public void clientIdOnlyWithNoValue() throws Exception {
+		AnnotationConfigApplicationContext context = load(Config.class, "oauth2-client-credentials.client-id");
+		assertThat(context.containsBean("myBean"), equalTo(true));
+		context.close();
+	}
+
+	private AnnotationConfigApplicationContext load(Class<?> config, String... env) {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		TestPropertyValues.of(env).applyTo(context);
+		context.register(config);
+		context.refresh();
+		return context;
+	}
+
+	@Configuration
+	@Conditional(OnOAuth2ClientCredentialsEnabled.class)
+	public static class Config {
+		@Bean
+		public String myBean() {
+			return "myBean";
+		}
+	}
+}

--- a/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/support/OnOAuth2ClientCredentialsEnabledTests.java
+++ b/spring-cloud-starter-task-composedtaskrunner/src/test/java/org/springframework/cloud/task/app/composedtaskrunner/support/OnOAuth2ClientCredentialsEnabledTests.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.task.app.composedtaskrunner.support;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+import org.junit.After;
 import org.junit.Test;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -30,9 +31,18 @@ import org.springframework.context.annotation.Configuration;
  */
 public class OnOAuth2ClientCredentialsEnabledTests {
 
+	private AnnotationConfigApplicationContext context;
+
+	@After
+	public void teardown() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
 	@Test
 	public void noPropertySet() throws Exception {
-		AnnotationConfigApplicationContext context = load(Config.class);
+		this.context = load(Config.class);
 		assertThat(context.containsBean("myBean"), equalTo(false));
 		context.close();
 	}
@@ -44,16 +54,14 @@ public class OnOAuth2ClientCredentialsEnabledTests {
 
 	@Test
 	public void propertyClientId() throws Exception {
-		AnnotationConfigApplicationContext context = load(Config.class, "oauth2-client-credentials.client-id:12345");
+		this.context = load(Config.class, "oauth2-client-credentials.client-id:12345");
 		assertThat(context.containsBean("myBean"), equalTo(true));
-		context.close();
 	}
 
 	@Test
 	public void clientIdOnlyWithNoValue() throws Exception {
-		AnnotationConfigApplicationContext context = load(Config.class, "oauth2-client-credentials.client-id");
+		this.context = load(Config.class, "oauth2-client-credentials.client-id");
 		assertThat(context.containsBean("myBean"), equalTo(true));
-		context.close();
 	}
 
 	private AnnotationConfigApplicationContext load(Class<?> config, String... env) {


### PR DESCRIPTION
* Use Spring Security `5.2` to obtain OAuth2 access token
* Add additional configuration properties:
  - oauth2ClientCredentials.clientId
  - oauth2ClientCredentials.clientSecret
  - oauth2ClientCredentials.tokenUri
  - oauth2ClientCredentials.scopes

resolves https://github.com/spring-cloud-task-app-starters/composed-task-runner/issues/97

depends on PR https://github.com/spring-cloud/spring-cloud-common-security-config/pull/64
(Issue https://github.com/spring-cloud/spring-cloud-common-security-config/issues/63)