### PR TITLE
gh-102 Update Spring Security dependency to 5.2.1.RELEASE

### DIFF
--- a/spring-cloud-starter-task-composedtaskrunner/pom.xml
+++ b/spring-cloud-starter-task-composedtaskrunner/pom.xml
@@ -14,8 +14,8 @@
     </parent>
 
     <properties>
-        <spring-cloud-common-security-config.version>1.2.0.BUILD-SNAPSHOT</spring-cloud-common-security-config.version>
-        <spring-security.version>5.2.0.RC1</spring-security.version>
+        <spring-cloud-common-security-config.version>1.1.3.RELEASE</spring-cloud-common-security-config.version>
+        <spring-security.version>5.2.0.RELEASE</spring-security.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
- Revert Spring Cloud Common Security dependency to `1.1.3.RELEASE`

Resolves https://github.com/spring-cloud-task-app-starters/composed-task-runner/issues/102